### PR TITLE
SNS Logout 로직 수정

### DIFF
--- a/Pillanner/SignUp/LoginVC_APPLE_Login.swift
+++ b/Pillanner/SignUp/LoginVC_APPLE_Login.swift
@@ -49,8 +49,16 @@ extension LoginViewController {
             // Sign in with Firebase.
             Auth.auth().signIn(with: credential) { (result, error) in
                 if let error = error {
-                    print(error.localizedDescription)
-                    return
+                    let code = (error as NSError).code
+                    print("firebase auth error code : ", code)
+                    switch code {
+                    case 17007 :
+                        print("이미 같은 이메일로 가입된 ID가 있습니다.")
+                        let nextVC = TabBarController()
+                            nextVC.modalPresentationStyle = .fullScreen
+                        self.present(nextVC, animated: true)
+                    default : print(error.localizedDescription)
+                    }
                 }
                 print("애플 로그인에 성공했습니다.")
                 print("appleIDCredential : ", appleIDCredential)

--- a/Pillanner/SignUp/LoginVC_KAKAO_Login.swift
+++ b/Pillanner/SignUp/LoginVC_KAKAO_Login.swift
@@ -59,7 +59,16 @@ extension LoginViewController {
                 
                 Auth.auth().createUser(withEmail: (user?.kakaoAccount?.email)!, password: "123456") { result, error in
                     if let error = error {
-                        print(error)
+                        let code = (error as NSError).code
+                        print("firebase auth error code : ", code)
+                        switch code {
+                        case 17007 : 
+                            print("이미 같은 이메일로 가입된 ID가 있습니다.")
+                            let nextVC = TabBarController()
+                                nextVC.modalPresentationStyle = .fullScreen
+                            self.present(nextVC, animated: true)
+                        default : print(error.localizedDescription)
+                        }
                     }
                     
                     if let result = result {

--- a/Pillanner/SignUp/LoginVC_NAVER_Login.swift
+++ b/Pillanner/SignUp/LoginVC_NAVER_Login.swift
@@ -19,7 +19,7 @@ extension LoginViewController: NaverThirdPartyLoginConnectionDelegate {
         naverLoginInstance?.requestThirdPartyLogin()
     }
 
-    @objc func naverDisconnectButtonTapped() {
+    func naverDisconnect() {
         // 네이버 연결 끊기
         naverLoginInstance?.requestDeleteToken()
     }
@@ -64,8 +64,16 @@ extension LoginViewController: NaverThirdPartyLoginConnectionDelegate {
             // Firebase에 사용자 등록
             Auth.auth().createUser(withEmail: email, password: "123456") { result, error in
                 if let error = error {
-                    print("Firebase 사용자 등록 오류: \(error)")
-                    return
+                    let code = (error as NSError).code
+                    print("firebase auth error code : ", code)
+                    switch code {
+                    case 17007 :
+                        print("이미 같은 이메일로 가입된 ID가 있습니다.")
+                        let nextVC = TabBarController()
+                            nextVC.modalPresentationStyle = .fullScreen
+                        self.present(nextVC, animated: true)
+                    default : print(error.localizedDescription)
+                    }
                 }
 
                 if let result = result {
@@ -80,6 +88,7 @@ extension LoginViewController: NaverThirdPartyLoginConnectionDelegate {
                             nickname: "아직 설정 전"
                         )
                     )
+                    self.naverDisconnect()
                     let nextVC = SNSLoginViewController()
                     nextVC.modalPresentationStyle = .fullScreen
                     self.present(nextVC, animated: true)
@@ -91,23 +100,27 @@ extension LoginViewController: NaverThirdPartyLoginConnectionDelegate {
 
     // 로그인 버튼을 눌렀을 경우 열게 될 브라우저
     func oauth20ConnectionDidOpenInAppBrowser(forOAuth request: URLRequest!) {
-
+        print(#function)
     }
 
     func oauth20ConnectionDidFinishRequestACTokenWithRefreshToken() {
         // 리프레시 토큰 처리
+        print(#function)
     }
 
     func oauth20ConnectionDidFinishDeleteToken() {
         // 토큰 삭제 처리
+        print(#function)
     }
 
     func oauth20Connection(_ oauthConnection: NaverThirdPartyLoginConnection!, didFailWithError error: Error!) {
         // 로그인 실패 처리
+        print(#function)
     }
 
     func oauth20ConnectionDidReceiveAccessToken(_ accessToken: String!, tokenType: String!, expiresIn: String!) {
         // 액세스 토큰 수신 처리
+        print(#function)
     }
 
 }

--- a/Pillanner/SignUp/SNSLoginViewController.swift
+++ b/Pillanner/SignUp/SNSLoginViewController.swift
@@ -84,25 +84,6 @@ class SNSLoginViewController: UIViewController, UITextFieldDelegate {
         pillannerFlagImage.frame.size.height = self.view.frame.height * 0.1
     }
     
-    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        // Calculate new size based on text content
-        let currentText = (textField.text ?? "") as NSString
-        let newText = currentText.replacingCharacters(in: range, with: string) as NSString
-        let width = newText.size(withAttributes: [NSAttributedString.Key.font: textField.font!]).width + 20 // Add padding
-        
-        // Remove existing width constraint (if exists)
-        textField.snp.removeConstraints()
-        
-        // Add new width constraint
-        textField.snp.makeConstraints {
-            $0.centerX.centerY.equalToSuperview()
-            $0.width.equalTo(width)
-        }
-        
-        return true
-    }
-
-    
     private func setConstraints() {
         pillannerFlagImage.snp.makeConstraints{
             $0.centerX.equalToSuperview()
@@ -113,6 +94,8 @@ class SNSLoginViewController: UIViewController, UITextFieldDelegate {
             $0.top.equalTo(pillannerFlagImage.snp.bottom).offset(30)
         }
         setNameTextField.snp.makeConstraints{
+            $0.left.equalToSuperview().offset(sidePaddingValue)
+            $0.right.equalToSuperview().offset(-sidePaddingValue)
             $0.centerX.centerY.equalToSuperview()
         }
         setNameButton.snp.makeConstraints({


### PR DESCRIPTION
SNS Logout 로직 수정
SNSLoginVC 텍스트필드 사이즈 수정 ( 유동적으로 조절 가능한 Size -> 좌우 여백 고정한 full size 텍스트필드 )

로직 변경사항
- SNS 로그인한 상태에서 로그아웃 한 뒤, 다시 로그인 할 경우 이미 가입된 경우에 바로 메인화면으로 이동

아직 테스트해보지 못한 경우의수가 있을 수 있습니다.. 틈틈히 실기기테스트를 통해 본인의 아이디를 생성 후 여러가지 시도해보면서 고쳐야 할 로직을 발견해주시면 감사하겠습니다ㅎㅎ