### PR TITLE
[Fix] SignOut 회원탈퇴 시 firestore DB 도큐먼트 삭제 부분 - 불가

### DIFF
--- a/Pillanner/Model/DataManager.swift
+++ b/Pillanner/Model/DataManager.swift
@@ -119,26 +119,12 @@ final class DataManager {
         }
     }
     
-    func deleteUserData(userID: String) {
+    // 회원탈퇴 메서드
+    func deleteUserData(UID: String) {
+        // Firestore DB 삭제 (Document 통째로 삭제)
         let userCollection = db.collection("Users")
-        let query = userCollection.whereField("ID", isEqualTo: userID)
+        userCollection.document(UID).delete()
         
-        // Firestore DB 삭제 & UserDefaults 삭제
-        query.getDocuments{ (snapshot, error) in
-            guard let snapshot = snapshot, !snapshot.isEmpty else {
-                print("데이터가 없어용")
-                return
-            }
-            let ref = userCollection.document(snapshot.documents[0].documentID)
-            UserDefaults.standard.removeObject(forKey: "UID")
-            UserDefaults.standard.removeObject(forKey: "ID")
-            UserDefaults.standard.removeObject(forKey: "Password")
-            UserDefaults.standard.removeObject(forKey: "Nickname")
-            UserDefaults.standard.removeObject(forKey: "SignUpPath")
-            UserDefaults.standard.removeObject(forKey: "isAutoLoginActivate")
-            ref.delete()
-            print("데이터 삭제 완료")
-        }
         // Firebase Auth 탈퇴
         if let user = Auth.auth().currentUser {
             print("Firebase 탈퇴를 진행합니다.")
@@ -174,7 +160,7 @@ final class DataManager {
                                 "DueDate": pill.dueDate,
                                 "Intake": pill.intake,
                                 "Dosage": pill.dosage,
-                                "alarmStatus": pill.alarmStatus
+                                "AlarmStatus": pill.alarmStatus
                             ])
                             print("약 등록 완료")
                             return

--- a/Pillanner/SignUp/LoginVC_APPLE_Login.swift
+++ b/Pillanner/SignUp/LoginVC_APPLE_Login.swift
@@ -51,28 +51,6 @@ extension LoginViewController {
                 if let error = error {
                     let code = (error as NSError).code
                     print("firebase auth error code : ", code)
-                    switch code {
-                    case 17007 :
-                        DataManager.shared.readUserData(userID: idTokenString) { userData in
-                            guard let userData = userData else { return }
-                            if userData["SignUpPath"]! == "애플" {
-                                UserDefaults.standard.set(userData["UID"]!, forKey: "UID")
-                                UserDefaults.standard.set(userData["ID"]!, forKey: "ID")
-                                UserDefaults.standard.set(userData["Password"]!, forKey: "Password")
-                                UserDefaults.standard.set(userData["Nickname"]!, forKey: "Nickname")
-                                UserDefaults.standard.set(userData["SignUpPath"]!, forKey: "SignUpPath")
-                                UserDefaults.standard.set(true, forKey: "isAutoLoginActivate")
-                                let nextVC = TabBarController()
-                                    nextVC.modalPresentationStyle = .fullScreen
-                                self.present(nextVC, animated: true)
-                            } else {
-                                let alert = UIAlertController(title: "로그인 실패", message: "이미 가입된 이메일입니다.", preferredStyle: .alert)
-                                alert.addAction(UIAlertAction(title: "확인", style: .cancel))
-                                self.present(alert, animated: true)
-                            }
-                        }
-                    default : print(error.localizedDescription)
-                    }
                 }
                 print("애플 로그인에 성공했습니다.")
                 print("appleIDCredential : ", appleIDCredential)

--- a/Pillanner/SignUp/LoginVC_NAVER_Login.swift
+++ b/Pillanner/SignUp/LoginVC_NAVER_Login.swift
@@ -79,6 +79,7 @@ extension LoginViewController: NaverThirdPartyLoginConnectionDelegate {
                                 UserDefaults.standard.set(userData["Nickname"]!, forKey: "Nickname")
                                 UserDefaults.standard.set(userData["SignUpPath"]!, forKey: "SignUpPath")
                                 UserDefaults.standard.set(true, forKey: "isAutoLoginActivate")
+                                Auth.auth().signIn(withEmail: email, password: "123456")
                                 let nextVC = TabBarController()
                                     nextVC.modalPresentationStyle = .fullScreen
                                 self.present(nextVC, animated: true)

--- a/Pillanner/SignUp/SNSLoginViewController.swift
+++ b/Pillanner/SignUp/SNSLoginViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import SnapKit
+import FirebaseAuth
 
 class SNSLoginViewController: UIViewController, UITextFieldDelegate {
     
@@ -117,6 +118,7 @@ class SNSLoginViewController: UIViewController, UITextFieldDelegate {
             UserDefaults.standard.set(self.setNameTextField.text!, forKey: "Nickname")
             DataManager.shared.updateUserData(userID: userID, changedPassword: "sns", changedName: self.setNameTextField.text!)
             
+            Auth.auth().signIn(withEmail: userID, password: "123456")
             let initialSetUpStartVC = UINavigationController(rootViewController: InitialSetupStartViewController(nickName: self.setNameTextField.text!))
             initialSetUpStartVC.modalPresentationStyle = .fullScreen
             self.present(initialSetUpStartVC, animated: true)

--- a/Pillanner/SignUp/SignUpVC_Extension.swift
+++ b/Pillanner/SignUp/SignUpVC_Extension.swift
@@ -80,7 +80,7 @@ extension SignUpViewController {
                             print(error.localizedDescription)
                             return
                         }
-                        // 에러가 없다면 사용자에게 인증코드와 verifiacationID(인증 ID) 전달
+                        // 에러가 없다면 사용자에게 인증코드와 verificationID(인증 ID) 전달
                         print("@@@@@@@@@@@@@@@@@@@ 인증번호 발송 @@@@@@@@@@@@@@@@@@")
                         self.getSetTime()
                         self.ifPhoneNumberIsEmptyLabel.text = ""

--- a/Pillanner/UserMain/Setting/UserInfoView.swift
+++ b/Pillanner/UserMain/Setting/UserInfoView.swift
@@ -14,6 +14,11 @@ class UserInfoView: UIViewController, UITextFieldDelegate {
     private let topPaddingValue = 40
     private let buttonHeightValue = 35
     private let withdrawalButton = UIButton()
+    
+    var myUID: String {
+        return UserDefaults.standard.string(forKey: "UID") ?? ""
+    }
+    
     var myID: String {
         return UserDefaults.standard.string(forKey: "ID") ?? ""
     }
@@ -52,7 +57,7 @@ class UserInfoView: UIViewController, UITextFieldDelegate {
                 currentViewController = presentingViewController
             }
             currentViewController?.dismiss(animated: true, completion: nil)
-            DataManager.shared.deleteUserData(userID: self.myID)
+            DataManager.shared.deleteUserData(UID: self.myUID)
         }))
         alert.addAction(UIAlertAction(title: "아니오", style: .cancel, handler: nil))
         present(alert, animated: true)


### PR DESCRIPTION
문제 발견 : Rachel 이 회원탈퇴하는 과정 중 Firestore DB 에서 Userdata 데이터만 삭제되고 Pill 컬렉션은 그대로 남겨져있었음.
회원탈퇴를 하는 메서드에서 UID 값을 읽어와서 해당 도큐먼트를 통째로 delete 해봤지만 실패함.

이유 : Firestore 에서는 문서를 삭제해도 하위 컬렉션은 삭제되지 않음

<img width="904" alt="image" src="https://github.com/p1ll-so-h1gh/Pillanner/assets/105967740/ee09d1c5-fe5c-4a08-a510-e315a1d97929">

도큐먼트가 삭제될 때 너무 방대한 양의 데이터가 삭제될 수 있기 때문에 그렇다고 합니다.
회원탈퇴를 진행하고 Firestore 에서 기울어진 도큐먼트 UID 가 발견된다면, 삭제된 게 맞기는 하니 문제될 건 없지만, 가독성을 위해 수동으로 삭제 하시거나 저에게 삭제해달라고 말해주세요 ㅎㅎ

기타 회원가입부분 일부 코드수정도 했습니다!