### PR TITLE
가상전화번호 테스트코드 삭제

### DIFF
--- a/Pillanner/Find_ID_PW/FindIDVC_Extension.swift
+++ b/Pillanner/Find_ID_PW/FindIDVC_Extension.swift
@@ -30,9 +30,6 @@ extension FindIDViewController {
         if !phoneCertTextField.text!.isEmpty && availableGetCertNumberFlag == true {
             timerLabel.isHidden = false
             if availableGetCertNumberFlag == true {
-                //가상전화번호로 테스트하기 위한 코드 ---------------------------------------
-                Auth.auth().settings?.isAppVerificationDisabledForTesting = true
-                //------------------------------------------------------------------
                 PhoneAuthProvider.provider()
                     .verifyPhoneNumber(formatPhoneNumberForFirebase(phoneCertTextField.text!), uiDelegate: nil) { (verificationID, error) in
                         if let error = error {

--- a/Pillanner/Find_ID_PW/FindPWVC_Extension.swift
+++ b/Pillanner/Find_ID_PW/FindPWVC_Extension.swift
@@ -30,9 +30,6 @@ extension FindPWViewController {
         if !phoneCertTextField.text!.isEmpty && availableGetCertNumberFlag == true {
             timerLabel.isHidden = false
             if availableGetCertNumberFlag == true {
-                //가상전화번호로 테스트하기 위한 코드 ---------------------------------------
-                Auth.auth().settings?.isAppVerificationDisabledForTesting = true
-                //------------------------------------------------------------------
                 PhoneAuthProvider.provider()
                     .verifyPhoneNumber(formatPhoneNumberForFirebase(phoneCertTextField.text!), uiDelegate: nil) { (verificationID, error) in
                         if let error = error {

--- a/Pillanner/SignUp/SignUpVC_Extension.swift
+++ b/Pillanner/SignUp/SignUpVC_Extension.swift
@@ -68,9 +68,6 @@ extension SignUpViewController {
         if !phoneCertTextField.text!.isEmpty && availableGetCertNumberFlag == true {
             timerLabel.isHidden = false
             if availableGetCertNumberFlag == true {
-                //가상전화번호로 테스트하기 위한 코드 ---------------------------------------
-                Auth.auth().settings?.isAppVerificationDisabledForTesting = true
-                //------------------------------------------------------------------
                 PhoneAuthProvider.provider()
                     .verifyPhoneNumber(formatPhoneNumberForFirebase(phoneCertTextField.text!), uiDelegate: nil) { (verificationID, error) in
                         if let error = error {


### PR DESCRIPTION
가상전화번호 테스트코드 삭제해서 이제 회원가입 시 실제 전화번호로 인증번호 받을 수 있습니다.