### PR TITLE
[chore] 회원가입 전화번호 인증단계 에러 수정

### DIFF
--- a/Pillanner.xcodeproj/project.pbxproj
+++ b/Pillanner.xcodeproj/project.pbxproj
@@ -55,7 +55,6 @@
 		560EC5B92B9898F400FF0D37 /* DosageAddViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560EC5B82B9898F400FF0D37 /* DosageAddViewController.swift */; };
 		560EC5BB2B98991800FF0D37 /* WeekdaySelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560EC5BA2B98991800FF0D37 /* WeekdaySelectionViewController.swift */; };
 		560EC5BD2B98995100FF0D37 /* InitialSetupStartViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560EC5BC2B98995100FF0D37 /* InitialSetupStartViewController.swift */; };
-		56244AB12BA971D200702CA1 /* Secrets.plist in Resources */ = {isa = PBXBuildFile; fileRef = 56244AB02BA971D200702CA1 /* Secrets.plist */; };
 		5672C88B2BA33474004D4DAD /* NoticeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5672C88A2BA33474004D4DAD /* NoticeViewController.swift */; };
 		5672C88F2BA3349B004D4DAD /* TermsofUseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5672C88E2BA3349B004D4DAD /* TermsofUseViewController.swift */; };
 		5672C8912BA334AA004D4DAD /* PrivacyPolicyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5672C8902BA334AA004D4DAD /* PrivacyPolicyViewController.swift */; };
@@ -89,6 +88,7 @@
 		C490C8922B8EE9AB00DFACD8 /* DataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C490C8912B8EE9AB00DFACD8 /* DataManager.swift */; };
 		C4A55A052B999EEC0084AF16 /* SNSLogin_Kakao.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4A55A042B999EEC0084AF16 /* SNSLogin_Kakao.swift */; };
 		C4A55A072B99B9E40084AF16 /* SNSLogin_Apple.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4A55A062B99B9E40084AF16 /* SNSLogin_Apple.swift */; };
+		C4DFE6E82BB133E2004E28B1 /* Secrets.plist in Resources */ = {isa = PBXBuildFile; fileRef = C4DFE6E72BB133E2004E28B1 /* Secrets.plist */; };
 		CC16976F2B8DDA13008276B0 /* PillListCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC16976E2B8DDA12008276B0 /* PillListCollectionViewCell.swift */; };
 		CC16979A2B9021C0008276B0 /* PillCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC1697992B9021C0008276B0 /* PillCell.swift */; };
 		CC16979C2B9021D2008276B0 /* IntakeDateCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC16979B2B9021D2008276B0 /* IntakeDateCell.swift */; };
@@ -123,7 +123,6 @@
 		560EC5B82B9898F400FF0D37 /* DosageAddViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DosageAddViewController.swift; sourceTree = "<group>"; };
 		560EC5BA2B98991800FF0D37 /* WeekdaySelectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeekdaySelectionViewController.swift; sourceTree = "<group>"; };
 		560EC5BC2B98995100FF0D37 /* InitialSetupStartViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialSetupStartViewController.swift; sourceTree = "<group>"; };
-		56244AB02BA971D200702CA1 /* Secrets.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Secrets.plist; sourceTree = "<group>"; };
 		5672C88A2BA33474004D4DAD /* NoticeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeViewController.swift; sourceTree = "<group>"; };
 		5672C88E2BA3349B004D4DAD /* TermsofUseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsofUseViewController.swift; sourceTree = "<group>"; };
 		5672C8902BA334AA004D4DAD /* PrivacyPolicyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyPolicyViewController.swift; sourceTree = "<group>"; };
@@ -149,6 +148,7 @@
 		C4A55A032B999E0A0084AF16 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		C4A55A042B999EEC0084AF16 /* SNSLogin_Kakao.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNSLogin_Kakao.swift; sourceTree = "<group>"; };
 		C4A55A062B99B9E40084AF16 /* SNSLogin_Apple.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNSLogin_Apple.swift; sourceTree = "<group>"; };
+		C4DFE6E72BB133E2004E28B1 /* Secrets.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Secrets.plist; path = ../../../Downloads/Secrets.plist; sourceTree = "<group>"; };
 		CC16976E2B8DDA12008276B0 /* PillListCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PillListCollectionViewCell.swift; sourceTree = "<group>"; };
 		CC1697992B9021C0008276B0 /* PillCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PillCell.swift; sourceTree = "<group>"; };
 		CC16979B2B9021D2008276B0 /* IntakeDateCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntakeDateCell.swift; sourceTree = "<group>"; };
@@ -308,7 +308,7 @@
 		147505872BAEBBF200A646AB /* Configuration */ = {
 			isa = PBXGroup;
 			children = (
-				56244AB02BA971D200702CA1 /* Secrets.plist */,
+				C4DFE6E72BB133E2004E28B1 /* Secrets.plist */,
 				C4A55A032B999E0A0084AF16 /* Config.xcconfig */,
 			);
 			path = Configuration;
@@ -587,8 +587,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C4DFE6E82BB133E2004E28B1 /* Secrets.plist in Resources */,
 				1438F6AC2B8F0A53006D2939 /* GoogleService-Info.plist in Resources */,
-				56244AB12BA971D200702CA1 /* Secrets.plist in Resources */,
 				14D2BE6D2B84BBC20006AC51 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Pillanner/Beginning/SignUp/SignUpVC_Extension.swift
+++ b/Pillanner/Beginning/SignUp/SignUpVC_Extension.swift
@@ -68,6 +68,9 @@ extension SignUpViewController {
         if !phoneCertTextField.text!.isEmpty && availableGetCertNumberFlag == true {
             timerLabel.isHidden = false
             if availableGetCertNumberFlag == true {
+                // 가상번호 테스트용 코드 (에러수정 시 사용예정)==============================
+                //Auth.auth().settings?.isAppVerificationDisabledForTesting = true
+                //=================================================================
                 PhoneAuthProvider.provider()
                     .verifyPhoneNumber(formatPhoneNumberForFirebase(phoneCertTextField.text!), uiDelegate: nil) { (verificationID, error) in
                         if let error = error {
@@ -83,7 +86,7 @@ extension SignUpViewController {
                         self.ifPhoneNumberIsEmptyLabel.text = ""
                         self.certNumberAvailableLabel.text = "인증번호가 발송되었습니다."
                         self.getCertNumberButton.setTitle("재전송", for: .normal)
-                        self.getCertNumberButton.setTitleColor(UIColor.lightGray, for: .normal)
+                        self.getCertNumberButton.isEnabled = false
                         self.certNumberAvailableLabel.textColor = .systemBlue
                         self.certNumberAvailableLabel.font = UIFont.systemFont(ofSize: UIFont.systemFontSize)
                         UserDefaults.standard.setValue(verificationID!, forKey: "firebaseVerificationID")
@@ -125,7 +128,7 @@ extension SignUpViewController {
             timerLabel.isHidden = true
             limitTime = 180
             availableGetCertNumberFlag = true
-            getCertNumberButton.setTitleColor(UIColor.black, for: .normal)
+            getCertNumberButton.isEnabled = true
             certNumberAvailableLabel.text = "인증번호 유효시간이 초과했습니다."
             certNumberAvailableLabel.textColor = .red
             certNumberAvailableLabel.font = UIFont.systemFont(ofSize: UIFont.systemFontSize)
@@ -141,12 +144,20 @@ extension SignUpViewController {
         Auth.auth().signIn(with: credential) { authData, error in
             if let error = error {
                 print("errorCode: \(error)")
-                print("인증번호가 일치하지 않습니다.")
-                self.certNumberTextField.text = ""
-                // 인증번호 매칭 에러 - Alert
-                let alert = UIAlertController(title: "인증 실패", message: "인증번호가 올바르지 않습니다.", preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: "확인", style: .default))
-                self.present(alert, animated: true)
+                let code = (error as NSError).code
+                switch code {
+                case 17051 :
+                    let alert = UIAlertController(title: "전화번호 인증", message: "처리중입니다.", preferredStyle: .alert)
+                    alert.addAction(UIAlertAction(title: "확인", style: .default))
+                    self.present(alert, animated: true)
+                case 17044 :
+                    self.certNumberTextField.text = ""
+                    // 인증번호 매칭 에러 - Alert
+                    let alert = UIAlertController(title: "인증 실패", message: "인증번호가 올바르지 않습니다.", preferredStyle: .alert)
+                    alert.addAction(UIAlertAction(title: "확인", style: .default))
+                    self.present(alert, animated: true)
+                default : print(error.localizedDescription)
+                }
             } else {
                 guard let authData = authData else { return }
                 self.myUID = authData.user.uid // 가입하기 버튼 눌렀을 때 넣어줄 UID값 미리 받는 부분
@@ -293,43 +304,28 @@ extension SignUpViewController {
     func unavailableSignUp() {
         if !idTextFieldFlag {
             idLabel.textColor = .red
-            
         }else {
             idLabel.textColor = .black
-            
         }
         if !nameTextFieldFlag {
             nameLabel.textColor = .red
-            
         }else {
             nameLabel.textColor = .black
-            
         }
         if !passwordTextFieldFlag {
             passwordLabel.textColor = .red
-            
         }else {
             passwordLabel.textColor = .black
-            
         }
         if !passwordReTextFieldFlag {
             passwordReLabel.textColor = .red
-            
         }else {
             passwordReLabel.textColor = .black
-            
         }
         if !phoneCertTextFieldFlag {
             phoneCertLabel.textColor = .red
-            
         }else {
             phoneCertLabel.textColor = .black
-            
-        }
-        if !certNumberTextFieldFlag {
-            
-        }else {
-            
         }
     }
     


### PR DESCRIPTION
가상번호로 테스트할 때는 인증번호 입력하고 확인버튼 여러번 눌러도 계속 확인되었다는 동작이었는데,
실제 번호로 테스트할때 보니까 확인버튼이 두번째 눌릴때부터는 Auth 에러가 발생하길래 해당부분 에러핸들링 추가해놨습니다.

현재는 이미 전송된 인증번호일 경우, 인증번호 잘못 입력된 경우 두 가지로만 에러핸들링이 되는 상태인데 또 다른 버그 발견 시 말씀해주세요~

추가로 인증번호받기 -> 재전송 버튼으로 바뀌는 부분 수정했습니다.(3분 초과 시 버튼 Enable)