### PR TITLE
[Fix] 카카오 회원가입/로그인 블랙스크린 에러해결

### DIFF
--- a/Pillanner/Beginning/Login/SNSLogin_Apple.swift
+++ b/Pillanner/Beginning/Login/SNSLogin_Apple.swift
@@ -61,7 +61,7 @@ extension LoginViewController {
                         UID: result!.user.uid,
                         ID: result!.user.email!,
                         password: "sns",
-                        nickname: "아직 설정 전",
+                        nickname: "(이름 없음)",
                         signUpPath: "애플"
                     )
                 )

--- a/Pillanner/Beginning/Login/SNSLogin_Kakao.swift
+++ b/Pillanner/Beginning/Login/SNSLogin_Kakao.swift
@@ -12,19 +12,15 @@ import UIKit
 
 extension LoginViewController {
     @objc func kakaoLoginButtonTapped() {
+        UserDefaults.standard.set("카카오", forKey: "SignUpPath")
         // 카카오톡 설치 여부 확인
         if (UserApi.isKakaoTalkLoginAvailable()) {
-            
             //카카오톡 앱을 통해 로그인
             UserApi.shared.loginWithKakaoTalk {(oauthToken, error) in
                 if let error = error {
-                    print(error)
-                    print("카카오앱 에러")
+                    print("카카오앱 에러 : ", error)
                 }
                 else {
-                    print("loginWithKakaoTalk() success.")
-                    print("카카오톡 앱으로 실행")
-                    //do something
                     _ = oauthToken
                     print("my kakao Token : ",oauthToken as Any)
                     self.signUpWithKakaoEmail()
@@ -34,13 +30,9 @@ extension LoginViewController {
             // 설치 안되어있으면 카카오 웹뷰로 로그인
             UserApi.shared.loginWithKakaoAccount {(oauthToken, error) in
                 if let error = error {
-                    print(error)
-                    print("카카오웹! 에러;")
+                    print("카카오웹 에러 : ", error)
                 }
                 else {
-                    print("loginWithKakaoTalk() success.")
-                    print("카카오톡 앱이 없어용~~")
-                    //do something
                     _ = oauthToken
                     self.signUpWithKakaoEmail()
                 }
@@ -61,9 +53,11 @@ extension LoginViewController {
                 Auth.auth().createUser(withEmail: (user?.kakaoAccount?.email)!, password: "123456") { result, error in
                     if let error = error {
                         let code = (error as NSError).code
+                        print("카카오톡 Firebase 가입 에러")
                         print("firebase auth error code : ", code)
                         switch code {
                         case 17007 :
+                            print("이미 카카오로 가입되어 있습니다.")
                             DataManager.shared.readUserData(userID: (user?.kakaoAccount?.email)!) { userData in
                                 guard let userData = userData else { return }
                                 if userData["SignUpPath"]! == "카카오" {
@@ -88,8 +82,7 @@ extension LoginViewController {
                     }
                     
                     if let result = result {
-                        print(result)
-                        print(result.user.uid)
+                        print("카카오톡으로 회원가입합니다.")
                         UserDefaults.standard.set(true, forKey: "isAutoLoginActivate")
                         // Firestore DB에 회원 정보 저장
                         DataManager.shared.createUserData(
@@ -97,7 +90,7 @@ extension LoginViewController {
                                 UID: result.user.uid,
                                 ID: (user?.kakaoAccount?.email)!,
                                 password: "sns",
-                                nickname: "아직 설정 전",
+                                nickname: "(이름 없음)",
                                 signUpPath: "카카오"
                             )
                         )

--- a/Pillanner/Beginning/Login/SNSLogin_Naver.swift
+++ b/Pillanner/Beginning/Login/SNSLogin_Naver.swift
@@ -15,6 +15,7 @@ private let naverLoginInstance = NaverThirdPartyLoginConnection.getSharedInstanc
 extension LoginViewController: NaverThirdPartyLoginConnectionDelegate {
     
     @objc func naverLoginButtonTapped() {
+        UserDefaults.standard.set("네이버", forKey: "SignUpPath")
         naverLoginInstance?.delegate = self
         naverLoginInstance?.requestThirdPartyLogin()
     }
@@ -102,7 +103,7 @@ extension LoginViewController: NaverThirdPartyLoginConnectionDelegate {
                             UID: result.user.uid,
                             ID: email,
                             password: "sns",
-                            nickname: "아직 설정 전",
+                            nickname: "(이름 없음)",
                             signUpPath: "네이버"
                         )
                     )

--- a/Pillanner/Beginning/SignUp/SNSLoginViewController.swift
+++ b/Pillanner/Beginning/SignUp/SNSLoginViewController.swift
@@ -114,7 +114,6 @@ class SNSLoginViewController: UIViewController, UITextFieldDelegate {
         alert.addAction(UIAlertAction(title: "취소", style: .cancel))
         alert.addAction(UIAlertAction(title: "확인", style: .default, handler: { _ in
             UserDefaults.standard.set(true, forKey: "isAutoLoginActivate") //SNS 회원가입은 자동로그인을 기본값으로 설정(true)
-            // setNameTextField.text 값은 옵셔널 바인딩해서 사용하는게
             UserDefaults.standard.set(self.setNameTextField.text!, forKey: "Nickname")
             DataManager.shared.updateUserData(userID: userID, changedPassword: "sns", changedName: self.setNameTextField.text!)
             

--- a/Pillanner/Global/Feature/DataManager.swift
+++ b/Pillanner/Global/Feature/DataManager.swift
@@ -125,6 +125,14 @@ final class DataManager {
         let userCollection = db.collection("Users")
         userCollection.document(UID).delete()
         
+        // UserDefaults 삭제
+        UserDefaults.standard.removeObject(forKey: "UID")
+        UserDefaults.standard.removeObject(forKey: "ID")
+        UserDefaults.standard.removeObject(forKey: "Password")
+        UserDefaults.standard.removeObject(forKey: "Nickname")
+        UserDefaults.standard.removeObject(forKey: "SignUpPath")
+        UserDefaults.standard.set(false, forKey: "isAutoLoginActivate")
+        
         // Firebase Auth 탈퇴
         if let user = Auth.auth().currentUser {
             print("Firebase 탈퇴를 진행합니다.")

--- a/Pillanner/Global/SceneDelegate.swift
+++ b/Pillanner/Global/SceneDelegate.swift
@@ -38,16 +38,21 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     // 카카오톡 SDK 초기화
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        let SignUpPath = UserDefaults.standard.string(forKey: "SignUpPath") ?? ""
+        print("mySignUpPath : ", SignUpPath)
         if let url = URLContexts.first?.url {
-            if (AuthApi.isKakaoTalkLoginUrl(url)) {
-                _ = AuthController.handleOpenUrl(url: url)
+            switch(SignUpPath){
+            case "카카오" :
+                if (AuthApi.isKakaoTalkLoginUrl(url)) {
+                    _ = AuthController.handleOpenUrl(url: url)
+                }
+            case "네이버" :
+                NaverThirdPartyLoginConnection
+                    .getSharedInstance()?
+                    .receiveAccessToken(URLContexts.first?.url)
+            default : return
             }
         }
-        
-        // 네이버
-        NaverThirdPartyLoginConnection
-            .getSharedInstance()?
-            .receiveAccessToken(URLContexts.first?.url)
     }
     
     

--- a/Pillanner/MainView/UserStatus/Setting/UserInfoView.swift
+++ b/Pillanner/MainView/UserStatus/Setting/UserInfoView.swift
@@ -52,6 +52,17 @@ class UserInfoView: UIViewController, UITextFieldDelegate {
         // Show logout alert
         let alert = UIAlertController(title: "회원탈퇴", message: "정말 탈퇴하시겠습니까? 탈퇴시 PILLANNER에 기록된 정보들이 모두 삭제됩니다.", preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "네", style: .destructive, handler: { _ in
+            // 만약 카카오 로그인 한 경우, 카카오 토큰해제
+            if UserDefaults.standard.string(forKey: "SignUpPath")! == "카카오" {
+                UserApi.shared.unlink {(error) in
+                    if let error = error {
+                        print(error)
+                    }
+                    else {
+                        print("unlink() success.")
+                    }
+                }
+            }
             var currentViewController: UIViewController? = self.presentingViewController
             while let presentingViewController = currentViewController?.presentingViewController {
                 currentViewController = presentingViewController
@@ -138,6 +149,7 @@ import Foundation
 import Firebase
 import FirebaseFirestore
 import FirebaseAuth
+import KakaoSDKUser
 
 extension UserInfoView {
     

--- a/Pillanner/MainView/UserStatus/Setting/UserSettingViewController.swift
+++ b/Pillanner/MainView/UserStatus/Setting/UserSettingViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import SnapKit
+import KakaoSDKUser
 
 enum SettingSection: CaseIterable {
     case userInfo
@@ -175,6 +176,17 @@ class UserSettingViewController: UIViewController {
         alert.addAction(UIAlertAction(title: "네", style: .destructive, handler: { _ in
             // 로그아웃 처리
             print("로그아웃 합니다.")
+            if UserDefaults.standard.string(forKey: "SignUpPath")! == "카카오" {
+                // 카카오 로그아웃처리
+                UserApi.shared.unlink {(error) in
+                    if let error = error {
+                        print(error)
+                    }
+                    else {
+                        print("unlink() success.")
+                    }
+                }
+            }
             UserDefaults.standard.set(false, forKey: "isAutoLoginActivate")
             var currentViewController: UIViewController? = self.presentingViewController
             while let presentingViewController = currentViewController?.presentingViewController {


### PR DESCRIPTION
카카오 로그인 또는 회원가입 시 블랙스크린 뜨는 현상해결.

원인 : SceneDelegate.swift 의 func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) 메서드에서 카카오 api 와 네이버 api 가 같은 URL 을 가지고 동시처리함.

해결 : 해당 메서드는 앱이 특정 URL 을 열때, 실행되는 메서드로 (앱 -> 앱) 으로 데이터를 넘겨줄때 사용됨. (카카오톡 or 네이버 -> 필래너)
-> 로그인 뷰컨에서 카카오, 네이버 아이콘 클릭시 UserDefault - SignUpPath Set. ("카카오", "네이버")
-> SceneDelegate 내에서 URL 메서드 실행시, UserDefault-SignUpPath 값으로 분기처리

추가 변경사항
- 회원탈퇴 시, UserDefault 값 삭제 추가
- 로그아웃, 회원탈퇴 시 로그인방법이 카카오톡인 경우 카카오톡 토큰 해제 코드 추가 (네이버 토큰해제는 아직..방법 구상중)
- 소셜회원가입 도중 앱 종료 시, 기본 설정 닉네임 변경 ( 아직 설정 전 -> (이름없음) )